### PR TITLE
Don't include the query string when signing

### DIFF
--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -474,7 +474,7 @@ module ChefAPI
         :http_method => verb,
         :body        => request.body || '',
         :host        => "#{uri.host}:#{uri.port}",
-        :path        => request.path,
+        :path        => uri.path,
         :timestamp   => Time.now.utc.iso8601,
         :user_id     => client,
         :file        => '',


### PR DESCRIPTION
The query string should not be included in the hashed path when
constructing the signed header.

Unfortunately, I couldn't figure out a good way to test this.
