### PR TITLE
Require I18n >= 0.6.6

### DIFF
--- a/chef-api.gemspec
+++ b/chef-api.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'i18n',                  '~> 0.6'
+  spec.add_dependency 'i18n',                  '~> 0.6', '>= 0.6.6'
   spec.add_dependency 'mixlib-authentication', '~> 1.3'
 end


### PR DESCRIPTION
I18n.enforce_available_locales was added in 0.6.6:

https://github.com/svenfuchs/i18n/commit/3b6e56e06fd70f6e4507996b017238505e66608c
