### PR TITLE
Fix issue providing pem file at unexpanded path

### DIFF
--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -363,7 +363,7 @@ module ChefAPI
         @parsed_key = key
       end
 
-      if key =~ /(.+)\.pem$/ || File.exists?(key)
+      if key =~ /(.+)\.pem$/ || File.exists?(File.expand_path(key))
         log.debug "Detected private key is the path to a file"
         contents = File.read(File.expand_path(key))
         @parsed_key = OpenSSL::PKey::RSA.new(contents)


### PR DESCRIPTION
This fixes the case where a key file path is provided which does not have the .pem extension and an unexpanded path.

e.g.

`~/.ssh/id_rsa`
