### PR TITLE
Fix Hash representation of a data bag item

### DIFF
--- a/lib/chef-api/resources/data_bag_item.rb
+++ b/lib/chef-api/resources/data_bag_item.rb
@@ -31,5 +31,22 @@ module ChefAPI
       id = attributes.delete(:id) || attributes.delete('id')
       super({ id: id, data: attributes }, prefix)
     end
+
+    #
+    # Override the to_hash method to move data to the top scope of hash representation of this resource.
+    #
+    # @return [Hash]
+    #
+    def to_hash()
+      {}.tap do |hash|
+        _attributes.each do |key, value|
+          if key == :data
+            hash.merge! value
+          else
+            hash[key] = value.respond_to?(:to_hash) ? value.to_hash : value
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The hash represation of a data bag item was :

``` ruby
{
  :id  => "devel",
  :data => { :foo => "bar" }
}
```

Now we got the right representation :

``` ruby
{
  :id  => "devel",
  :foo => "bar"
}
```
