### PR TITLE
Add `shuffle!` to CollectionProxy

### DIFF
--- a/lib/chef-api/resources/collection_proxy.rb
+++ b/lib/chef-api/resources/collection_proxy.rb
@@ -115,6 +115,14 @@ module ChefAPI
     alias_method :size, :count
 
     #
+    # Shuffle the order of the items in this collection.
+    #
+    def shuffle!
+      @collection = Hash[collection.to_a.shuffle]
+      self
+    end
+
+    #
     # The string representation of this collection proxy.
     #
     # @return [String]


### PR DESCRIPTION
Sometime I'd like to enumerate the collection at random without warming up caches.
