### PR TITLE
Adding fix for SSL verification in v0.5.0

### DIFF
--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -245,9 +245,7 @@ module ChefAPI
 
         # Custom pem files, no problem!
         if ssl_pem_file
-          pem = File.read(ssl_pem_file)
-          connection.cert = OpenSSL::X509::Certificate.new(pem)
-          connection.key = OpenSSL::PKey::RSA.new(pem)
+          connection.ca_file = ssl_pem_file
           connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
 


### PR DESCRIPTION
Hello! I'm using version 0.5.0 of chef-api with Ruby 1.9.3 and an AWS OpsWorks server. I ran into an issue with connecting to the server with SSL verification enabled and using Amazon's provided PEM file. Turns out the issue is because the PEM they provide only has a Certificate, not both a Certificate and Key, so the connection is failing around [this line](https://github.com/sethvargo/chef-api/blob/v0.5.0/lib/chef-api/connection.rb#L250) when a key cannot be parsed. 

This PR is to replace the cert and key parsing lines with a single line leveraging the `ca_file` field for the PEM instead which seems to be a more reliable way of connecting with a non-standard PEM. I've only made the change to v0.5.0.